### PR TITLE
Just throwing up what I have so far

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+scripts/root
+python/venv
+python/spiffe.cert.pem
+python/spiffe.key.pem

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # pki-scratch
+
+
+## Building the CA with a root and intermediates

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Follow the prompts and you will get a directory called `root` in the scripts dir
 
 Run the following commands.
 NOTE: The security standing of the python cryptography library used in the example is not known. It was chosen for its API
-not its cryptographic guarantees.
+not its cryptographic guarantees. Here are its documented limitations -> https://cryptography.io/en/latest/limitations/
 
 ```
 $ cd python

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Follow the prompts and you will get a directory called `root` in the scripts dir
 
 ## Building a spiffe cert that is signed by the intermediate
 
-Run the following commands
+Run the following commands.
+NOTE: The security standing of the python cryptography library used in the example is not known. It was chosen for its API
+not its cryptographic guarantees.
 
 ```
 $ cd python

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,1 @@
+cryptography==1.7.2

--- a/python/spiffe/spiffe.py
+++ b/python/spiffe/spiffe.py
@@ -1,0 +1,95 @@
+from datetime import datetime, timedelta
+import sys
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes
+
+def generate_spiffe(identity,
+                    passphrase,
+                    intermediate_path,
+                    intermediate_secret):
+
+    key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend()
+    )
+
+    csr = x509.CertificateSigningRequestBuilder().subject_name(x509.Name([
+        x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"CA"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, u"San Francisco"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"Twilio"),
+        x509.NameAttribute(NameOID.COMMON_NAME, u"PA Spiffe Cert"),
+    ])).add_extension(
+        x509.SubjectAlternativeName([
+            # Describe what sites we want this certificate for.
+            x509.UniformResourceIdentifier(identity),
+        ]),
+        critical=False,
+        # Sign the CSR with our private key.
+    ).sign(key, hashes.SHA256(), default_backend())
+
+    # sign the csr with the intermediate cert
+
+    intermediate_key = None
+    with open("{}/private/intermediate.key.pem".format(intermediate_path), 'rb') as f:
+        intermediate_key = default_backend().load_pem_private_key(f.read(), intermediate_secret)
+
+    intermediate_cert = None
+    with open("{}/certs/intermediate.cert.pem".format(intermediate_path), 'rb') as f:
+        intermediate_cert = x509.load_pem_x509_certificate(f.read(), default_backend())
+
+    cert = x509.CertificateBuilder().subject_name(
+        csr.subject
+    ).issuer_name(
+        intermediate_cert.subject
+    ).public_key(
+        key.public_key()
+    ).serial_number(
+        x509.random_serial_number()
+    ).not_valid_before(
+        datetime.utcnow()
+    ).not_valid_after(
+        # Our certificate will be valid for 10 days
+        datetime.utcnow() + timedelta(days=10)
+    ).add_extension(
+        x509.SubjectAlternativeName([x509.UniformResourceIdentifier(identity)]),
+        critical=False,
+        # Sign our certificate with our private key
+    ).sign(intermediate_key, hashes.SHA256(), default_backend())
+
+
+    private_out = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.BestAvailableEncryption(passphrase))
+
+    certificate = cert.public_bytes(serialization.Encoding.PEM)
+
+    return private_out, certificate
+
+def generate_spiffe_to_file(private_key, certificate, file_prefix):
+    with open("{}.key.pem".format(file_prefix), 'wb') as f:
+        f.write(private_key)
+
+    with open("{}.cert.pem".format(file_prefix), 'wb') as f:
+        f.write(certificate)
+
+
+if __name__ == '__main__':
+    path_to_ca = sys.argv[1]
+    p_key, certificate = generate_spiffe("urn:spiffe:service:twilio.com:dev-us1:foo",
+                                         b"secret",
+                                         path_to_ca,
+                                         b'secret')
+    generate_spiffe_to_file(p_key, certificate, 'spiffe')
+
+
+# to check csr run $ openssl req -in spiffe.csr.pem -noout -text
+# to check private key run $ openssl rsa -in spiffe.key.pem -check
+# to check a certificate run $ openssl x509 -in certificate.crt -text -noout

--- a/python/spiffe/spiffe.py
+++ b/python/spiffe/spiffe.py
@@ -83,7 +83,7 @@ def generate_spiffe_to_file(private_key, certificate, file_prefix):
 
 if __name__ == '__main__':
     path_to_ca = sys.argv[1]
-    p_key, certificate = generate_spiffe("urn:spiffe:service:twilio.com:dev-us1:foo",
+    p_key, certificate = generate_spiffe("urn:spiffe:service:acme.com:acme-dev:foo-service",
                                          b"secret",
                                          path_to_ca,
                                          b'secret')

--- a/scripts/generate_ca.sh
+++ b/scripts/generate_ca.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -o pipefail
+set -e
+
+# generate root CA directories
+echo "### Building Root CA"
+mkdir -p root/ca
+pushd root/ca
+  mkdir certs crl newcerts private
+  chmod 700 private
+  touch index.txt
+  echo 1000 > serial
+popd
+
+cp root_openssl.conf root/ca/openssl.conf
+
+# build root CA
+pushd root/ca
+  openssl genrsa -aes256 -out private/ca.key.pem 4096
+  chmod 400 private/ca.key.pem
+  openssl req -config openssl.conf -key private/ca.key.pem -new -x509 -days 7300 -sha256 -extensions v3_ca -out certs/ca.cert.pem
+  chmod 444 certs/ca.cert.pem
+  openssl x509 -noout -text -in certs/ca.cert.pem
+popd
+
+# build intermediate Certs
+echo "#### Building Intermediate CA"
+mkdir -p root/ca/intermediate
+pushd root/ca/intermediate
+  mkdir certs crl csr newcerts private
+  chmod 700 private
+  touch index.txt
+  echo 1000 > serial
+  echo 1000 > crlnumber
+popd
+
+cp intermediate_openssl.conf root/ca/intermediate/openssl.conf
+
+pushd root/ca
+  openssl genrsa -aes256 -out intermediate/private/intermediate.key.pem 4096
+  chmod 400 intermediate/private/intermediate.key.pem
+  openssl req -config intermediate/openssl.conf -new -sha256  -key intermediate/private/intermediate.key.pem -out intermediate/csr/intermediate.csr.pem
+
+  #sign the intermediate with the root
+  openssl ca -config openssl.conf -extensions v3_intermediate_ca \
+      -days 3650 -notext -md sha256 \
+      -in intermediate/csr/intermediate.csr.pem \
+      -out intermediate/certs/intermediate.cert.pem
+
+  chmod 444 intermediate/certs/intermediate.cert.pem
+  openssl x509 -noout -text \
+          -in intermediate/certs/intermediate.cert.pem
+
+  cat intermediate/certs/intermediate.cert.pem \
+    certs/ca.cert.pem > intermediate/certs/ca-chain.cert.pem
+  chmod 444 intermediate/certs/ca-chain.cert.pem
+popd
+
+
+# create server and client certificates
+
+echo "#### Building Server and Client example certificated"
+pushd root/ca
+  openssl genrsa -out intermediate/private/www.example.com.key.pem 2048
+  chmod 400 intermediate/private/www.example.com.key.pem
+
+  openssl req -config intermediate/openssl.conf \
+      -key intermediate/private/www.example.com.key.pem \
+      -new -sha256 -out intermediate/csr/www.example.com.csr.pem
+
+  # CA sign the csr and return a certificate
+  openssl ca -config intermediate/openssl.conf -extensions server_cert -days 375 -notext -md sha256 -in intermediate/csr/www.example.com.csr.pem -out intermediate/certs/www.example.com.cert.pem
+
+  openssl x509 -noout -text \
+      -in intermediate/certs/www.example.com.cert.pem
+
+  openssl verify -CAfile intermediate/certs/ca-chain.cert.pem \
+      intermediate/certs/www.example.com.cert.pem
+popd

--- a/scripts/intermediate_openssl.conf
+++ b/scripts/intermediate_openssl.conf
@@ -1,0 +1,132 @@
+# OpenSSL intermediate CA configuration file.
+# Copy to `/root/ca/intermediate/openssl.cnf`.
+
+[ ca ]
+# `man ca`
+default_ca = CA_default
+
+[ CA_default ]
+# Directory and file locations.
+dir               = intermediate
+certs             = $dir/certs
+crl_dir           = $dir/crl
+new_certs_dir     = $dir/newcerts
+database          = $dir/index.txt
+serial            = $dir/serial
+RANDFILE          = $dir/private/.rand
+
+# The root key and root certificate.
+private_key       = $dir/private/intermediate.key.pem
+certificate       = $dir/certs/intermediate.cert.pem
+
+# For certificate revocation lists.
+crlnumber         = $dir/crlnumber
+crl               = $dir/crl/intermediate.crl.pem
+crl_extensions    = crl_ext
+default_crl_days  = 30
+
+# SHA-1 is deprecated, so use SHA-2 instead.
+default_md        = sha256
+
+name_opt          = ca_default
+cert_opt          = ca_default
+default_days      = 375
+preserve          = no
+policy            = policy_loose
+
+[ policy_strict ]
+# The root CA should only sign intermediate certificates that match.
+# See the POLICY FORMAT section of `man ca`.
+countryName             = match
+stateOrProvinceName     = match
+organizationName        = match
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ policy_loose ]
+# Allow the intermediate CA to sign a more diverse range of certificates.
+# See the POLICY FORMAT section of the `ca` man page.
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req ]
+# Options for the `req` tool (`man req`).
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+string_mask         = utf8only
+
+# SHA-1 is deprecated, so use SHA-2 instead.
+default_md          = sha256
+
+# Extension to add when the -x509 option is used.
+x509_extensions     = v3_ca
+
+[ req_distinguished_name ]
+# See <https://en.wikipedia.org/wiki/Certificate_signing_request>.
+countryName                     = Country Name (2 letter code)
+stateOrProvinceName             = State or Province Name
+localityName                    = Locality Name
+0.organizationName              = Organization Name
+organizationalUnitName          = Organizational Unit Name
+commonName                      = Common Name
+emailAddress                    = Email Address
+
+# Optionally, specify some defaults.
+countryName_default             = US
+stateOrProvinceName_default     = California
+localityName_default            =
+0.organizationName_default      = Spiffe
+organizationalUnitName_default  =
+emailAddress_default            =
+
+[ v3_ca ]
+# Extensions for a typical CA (`man x509v3_config`).
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ v3_intermediate_ca ]
+# Extensions for a typical intermediate CA (`man x509v3_config`).
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true, pathlen:0
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ usr_cert ]
+# Extensions for client certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = client, email
+nsComment = "OpenSSL Generated Client Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, emailProtection
+
+[ server_cert ]
+# Extensions for server certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = server
+nsComment = "OpenSSL Generated Server Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+
+[ crl_ext ]
+# Extension for CRLs (`man x509v3_config`).
+authorityKeyIdentifier=keyid:always
+
+[ ocsp ]
+# Extension for OCSP signing certificates (`man ocsp`).
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, digitalSignature
+extendedKeyUsage = critical, OCSPSigning

--- a/scripts/root_openssl.conf
+++ b/scripts/root_openssl.conf
@@ -1,0 +1,132 @@
+# OpenSSL root CA configuration file.
+# Copy to `/root/ca/openssl.cnf`.
+
+[ ca ]
+# `man ca`
+default_ca = CA_default
+
+[ CA_default ]
+# Directory and file locations.
+dir               = .
+certs             = $dir/certs
+crl_dir           = $dir/crl
+new_certs_dir     = $dir/newcerts
+database          = $dir/index.txt
+serial            = $dir/serial
+RANDFILE          = $dir/private/.rand
+
+# The root key and root certificate.
+private_key       = $dir/private/ca.key.pem
+certificate       = $dir/certs/ca.cert.pem
+
+# For certificate revocation lists.
+crlnumber         = $dir/crlnumber
+crl               = $dir/crl/ca.crl.pem
+crl_extensions    = crl_ext
+default_crl_days  = 30
+
+# SHA-1 is deprecated, so use SHA-2 instead.
+default_md        = sha256
+
+name_opt          = ca_default
+cert_opt          = ca_default
+default_days      = 375
+preserve          = no
+policy            = policy_strict
+
+[ policy_strict ]
+# The root CA should only sign intermediate certificates that match.
+# See the POLICY FORMAT section of `man ca`.
+countryName             = match
+stateOrProvinceName     = match
+organizationName        = match
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ policy_loose ]
+# Allow the intermediate CA to sign a more diverse range of certificates.
+# See the POLICY FORMAT section of the `ca` man page.
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req ]
+# Options for the `req` tool (`man req`).
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+string_mask         = utf8only
+
+# SHA-1 is deprecated, so use SHA-2 instead.
+default_md          = sha256
+
+# Extension to add when the -x509 option is used.
+x509_extensions     = v3_ca
+
+[ req_distinguished_name ]
+# See <https://en.wikipedia.org/wiki/Certificate_signing_request>.
+countryName                     = Country Name (2 letter code)
+stateOrProvinceName             = State or Province Name
+localityName                    = Locality Name
+0.organizationName              = Organization Name
+organizationalUnitName          = Organizational Unit Name
+commonName                      = Common Name
+emailAddress                    = Email Address
+
+# Optionally, specify some defaults.
+countryName_default             = US
+stateOrProvinceName_default     = California
+localityName_default            =
+0.organizationName_default      = Spiffe
+organizationalUnitName_default  =
+emailAddress_default            =
+
+[ v3_ca ]
+# Extensions for a typical CA (`man x509v3_config`).
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ v3_intermediate_ca ]
+# Extensions for a typical intermediate CA (`man x509v3_config`).
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true, pathlen:0
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ usr_cert ]
+# Extensions for client certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = client, email
+nsComment = "OpenSSL Generated Client Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, emailProtection
+
+[ server_cert ]
+# Extensions for server certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = server
+nsComment = "OpenSSL Generated Server Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+
+[ crl_ext ]
+# Extension for CRLs (`man x509v3_config`).
+authorityKeyIdentifier=keyid:always
+
+[ ocsp ]
+# Extension for OCSP signing certificates (`man ocsp`).
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, digitalSignature
+extendedKeyUsage = critical, OCSPSigning


### PR DESCRIPTION
    So the generate_ca.sh script will create a set of directories with a root and intermediate certificate and keys
    in a directory called root in the scripts director. To start over again you can just remove the root directory and run the script
    again. The root will use the root_openssl.conf and copy that into place. The intermediate will use the intermediate_openssl
    and copy that into place.

    Once you have the certificates from above your can then run the spiffe python script to build a spiffe cert and key. It will use the
    intermediate certificate from above and sign the spiffe cert with that. The python code is pretty rudimentary and probably not safe from a security
    POV, but good enough for a POC.